### PR TITLE
Switch to mongo 4.0. mongorestore from Mongo 4 works better with both…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && \
     ca-certificates \
     s3cmd \
     curl && apt-get clean
-ENV MONGO_MAJOR 3.6
+ENV MONGO_MAJOR 4.0
 RUN curl https://www.mongodb.org/static/pgp/server-$MONGO_MAJOR.pub -o /etc/apt/trusted.gpg.d/mongo-keyring.gpg
 RUN echo "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/$MONGO_MAJOR multiverse" | tee "/etc/apt/sources.list.d/mongodb.list"
 RUN apt-get update && \


### PR DESCRIPTION
… Mongo versions 3.6.x and 4.x witout additional parameters.

mongorestore from Mongo 3.6 against Mongo 4.0 server requires --forceTableScan.